### PR TITLE
reduce the use of Math.sqrt

### DIFF
--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -206,6 +206,7 @@
 
     // Ignore movement within this distance (px)
     var WIGGLE_THRESHOLD = 4;
+    var WIGGLE_THRESHOLD_SQUARE = WIGGLE_THRESHOLD * WIGGLE_THRESHOLD;
 
     // what constitues a flick (px/ms)
     var FLICK_SPEED = 0.5;
@@ -419,8 +420,8 @@
           this._moveQueue.push(event);
 
           // ignore movement within WIGGLE_THRESHOLD
-          var distance = Math.sqrt((dx * dx) + (dy * dy));
-          if (!this._gesture && distance > WIGGLE_THRESHOLD) {
+          var distance = (dx * dx) + (dy * dy);
+          if (!this._gesture && distance > WIGGLE_THRESHOLD_SQUARE) {
             this._gesture = adx > ady ? 'pan-x' : 'pan-y';
           }
 
@@ -522,19 +523,19 @@
       _getFastestMovement: function(event) {
         // detect flick based on fastest segment of movement
         var l = this._moveQueue.length;
-        var dt, tx, ty, tv, x = 0, y = 0, v = 0;
+        var dt, tx, ty, tv2, x = 0, y = 0, v2 = 0;
         for (var i = 0, m; i < l && (m = this._moveQueue[i]); i++) {
           dt = event.timeStamp - m.timeStamp;
           tx = (event.detail.x - m.detail.x) / dt;
           ty = (event.detail.y - m.detail.y) / dt;
-          tv = Math.sqrt(tx * tx + ty * ty);
-          if (tv > v) {
+          tv2 = tx * tx + ty * ty;
+          if (tv2 > v2) {
             x = tx;
             y = ty;
-            v = tv;
+            v2 = tv2;
           }
         }
-        return {x: x, y: y, v: v};
+        return {x: x, y: y, v: Math.sqrt(v2)};
       },
       _onSwipe: function(event) {
         if (event.detail.direction === 'right') {


### PR DESCRIPTION
sqrt is relatively slow, (a*a > b) is faster than (a > sqrt(b))