### PR TITLE
Fix getting locale-aware weekdays

### DIFF
--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -294,15 +294,14 @@
         return value.format(format);
       },
       _localeChanged: function(locale) {
-        // FIXME: use public API for getting locale-aware weekdays once moment/moment#2433 is fixed
-        var localeData = moment.localeData(locale);
-        var fdow = localeData._week.dow;
-        this.set('_firstDayOfWeek', fdow);
+        var localeMoment = moment();
+        localeMoment.locale(locale);
         var weekdays = [];
-        for (var i=fdow; i<7+fdow; i++) {
-          weekdays.push(localeData._weekdaysMin[i % 7]);
+        for (var i=0; i<7; i++) {
+          weekdays.push(localeMoment.weekday(i).format('dd'));
         }
-        this.set('_weekdays', weekdays);
+        this._weekdays = weekdays;
+        this._firstDayOfWeek = localeMoment.weekday(0).format('d');
       },
       _populate: function(currentYear, currentMonth, minDate, maxDate) {
         var date, month, weeks, day, d, dayInfo, monthData, months = [];


### PR DESCRIPTION
And as _localeChange isn't using localeData = moment.localeData(locale) anymore it will fix #47 where localeData was null for some reason.