### PR TITLE
Fix problem in date picker of nothing happening when selecting year at end of date range

### DIFF
--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -255,7 +255,7 @@
           value: null
         },
         /**
-         * The currently selected month (1-12) 
+         * The currently selected month (1-12)
          */
         currentMonth: {
           type: Number
@@ -572,8 +572,17 @@
           this.date = date = oldValue;
         }
         if (!this._withinValidRange(date)) {
-          console.warn('Date outside of valid range: ' + date);
-          this.date = date = oldValue;
+          if (this.minDate && date < this.minDate) {
+            date = this.minDate;
+          } else {
+            if (this.maxDate && date > this.maxDate) {
+              date = this.maxDate
+            } else {
+              console.warn('Date outside of valid range: ' + date);
+              this.date = date = oldValue;
+              return;
+            }
+          }
         }
         if (oldValue && date.getTime && oldValue.getTime && date.getTime() === oldValue.getTime()) {
           return;
@@ -611,7 +620,7 @@
         }
         this._scrollWidth = (this.$.calendar.offsetWidth * this._months.length);
         this.$.months.style.minWidth = this._scrollWidth + 'px';
-        var i = ((this.currentYear * 12) + this.currentMonth) - 
+        var i = ((this.currentYear * 12) + this.currentMonth) -
                  ((this._months[0].year * 12) + this._months[0].month);
         this._translateX(-i * this._containerWidth);
       },


### PR DESCRIPTION
This fixes an issue whereby trying to use the year selector for a year at the end of the date range, if the calendar has not previously been set to ensure the date when the year is selected is within range, everything reverts to the old date.

This is confusing and frustrating to the user who may (I would say mostly, but that is just my way of thinking) select the year before going on to then select the date within the year.