### PR TITLE
Fix for recursion and other tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-paper-date-picker
+polymer-paper-date-picker
 =================
 Material Design date picker, compatible with *Polymer 1.0*
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ component aims to be a clone of the date picker introduced in Android Lollipop.
 See the [component page](http://bendavis78.github.io/paper-date-picker/) for 
 full documentation.
 
+## Installing: 
+
+Install via Bower with: 
+
+```
+$ bower install --save polymer-paper-date-picker
+```
+
 ## Examples:
 
 Default picker:

--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -283,7 +283,6 @@
         'swiped': '_onSwipe'
       },
       ready: function() {
-        console.log('This is my fork.');
         this._updateToday();
         this.currentMonth = this.date.getMonth() + 1;
         this.currentYear = this.date.getFullYear();
@@ -387,12 +386,16 @@
       },
       _getDayClass: function(cssClass, date) {
         if (date) {
-          var timestamp = date.getTime();
+          var timestamp           = date.getTime(),
+              date_formatted      = moment(timestamp).format('YYYY-MM-DD'),
+              selected_formatted  = moment(this.date).format('YYYY-MM-DD');
+
           if (timestamp === this.today.getTime()) {
             cssClass += ' today';
           }
-          if (timestamp === this.date.getTime()) {
+          if(date_formatted === selected_formatted) {
             cssClass += ' selected';
+            console.log('Aha indeed');
             this.async(function() {
               this._updateSelection();
             });
@@ -601,10 +604,6 @@
         if (oldValue && date.getTime && oldValue.getTime && date.getTime() === oldValue.getTime()) {
           return;
         }
-        // clone the date object so as not to have unintended effects on bindings
-        date = new Date(date.getTime());
-        date.setHours(0, 0, 0, 0);
-        this.set('date', date);
         this._updateSelection();
       },
       _tapDay: function(event) {
@@ -638,11 +637,16 @@
         this._translateX(-i * this._containerWidth);
       },
       _updateSelection: function() {
-        // Force the day selection circle to maintain a 1:1 ratio
+        /**
+         *  Force the day selection circle to maintain a 1:1 ratio
+         *  
+         */
         var selected = this.$$('.day-item.selected');
+
         if (!selected) {
           return;
         }
+
         selected.style.height = '';
         selected.style.width = '';
         var w = selected.parentElement.offsetWidth;

--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -283,6 +283,7 @@
         'swiped': '_onSwipe'
       },
       ready: function() {
+        console.log('This is my fork.');
         this._updateToday();
         this.currentMonth = this.date.getMonth() + 1;
         this.currentYear = this.date.getFullYear();

--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -395,7 +395,6 @@
           }
           if(date_formatted === selected_formatted) {
             cssClass += ' selected';
-            console.log('Aha indeed');
             this.async(function() {
               this._updateSelection();
             });


### PR DESCRIPTION
I've made the following fixes:

### Infinite recursion bug

Infinite recursion on setting a date should no longer happen. This was happening because calling set on the components date property would trigger the observer watch function, which then sets the date and causes the loop. 

### Comparing dates and showing the selected date

When rendering the days inside the calendar, the timestamp for the current date was being compared against the calendar day. This could only work if the date property for the component was set to midnight for any given day, and in my case, no day was matched. 

I relaxed the check a little to only check the days are the same, not the times as well.