### PR TITLE
Update date only if there actually is a change

### DIFF
--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -597,12 +597,13 @@
         }
         this.currentYear = date.getFullYear();
         this.currentMonth = date.getMonth() + 1;
+        // Clone the date object to force Polymer binding to notice a change.
+        // But only trigger a notification if there actually is a difference.
+        date = new Date(date.getTime());
+        date.setHours(0, 0, 0, 0);
         if (oldValue && date.getTime && oldValue.getTime && date.getTime() === oldValue.getTime()) {
           return;
         }
-        // clone the date object so as not to have unintended effects on bindings
-        date = new Date(date.getTime());
-        date.setHours(0, 0, 0, 0);
         this.set('date', date);
         this._updateSelection();
       },


### PR DESCRIPTION
Calling this.set('date', date) with a cloned object leads to infinite recursion (which is broken by the browser once the maximum stack size is reached). 

I did not completely follow the Polymer code, but it looks like Polymer keeps calling _dateChanged() with alternating oldValue and newValue. The problem is that it cannot determine equality between them itself as they are objects.