### PR TITLE
Creating custom icon-set

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "moment-element": "bendavis78/moment-element#^1.1.0",
     "polymer": "Polymer/polymer#^1.1.0",
     "iron-icon": "PolymerElements/iron-icon#^1.0.7",
-    "iron-icons": "PolymerElements/iron-icons#^1.0.0",
+    "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.0",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
     "iron-media-query": "PolymerElements/iron-media-query#^1.0.0",
     "iron-resizable": "PolymerElements/iron-resizable-behavior#^1.0.0",

--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -1,11 +1,12 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../iron-icon/iron-icon.html">
-<link rel="import" href="../iron-icons/iron-icons.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">
 <link rel="import" href="../paper-styles/paper-styles.html">
 <link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
 <link rel="import" href="../moment-element/moment-with-locales-import.html">
+
+<link rel="import" href="paper-date-picker-icons.html">
 
 <dom-module id="paper-calendar">
   <template>
@@ -190,14 +191,14 @@
         <div class="flex col self-stretch">
           <div class="btn" on-tap="_swipePrevMonth">
             <paper-ripple center class="ripple circle"></paper-ripple>
-            <iron-icon class="icon flex" icon="chevron-left"></iron-icon>
+            <iron-icon class="icon flex" icon="paper-date-picker:chevron-left"></iron-icon>
           </div>
         </div>
         <div class="flex-5"></div>
         <div class="flex col self-stretch">
           <div class="btn" on-tap="_swipeNextMonth">
             <paper-ripple center class="ripple circle"></paper-ripple>
-            <iron-icon class="icon flex" icon="chevron-right"></iron-icon>
+            <iron-icon class="icon flex" icon="paper-date-picker:chevron-right"></iron-icon>
           </div>
         </div>
       </div>

--- a/paper-date-picker-icons.html
+++ b/paper-date-picker-icons.html
@@ -1,0 +1,11 @@
+<link rel="import" href="../iron-icon/iron-icon.html">
+<link rel="import" href="../iron-iconset-svg/iron-iconset-svg.html">
+
+<iron-iconset-svg size="24" name="paper-date-picker">
+	<svg>
+		<defs>
+			<g id="chevron-left"><path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"></path></g>
+			<g id="chevron-right"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"></path></g>
+		</defs>
+	</svg>
+</iron-iconset-svg>


### PR DESCRIPTION
The full iron-icons dependency was used in paper-calendar, however only two icons were actually used in this element. To increase performance and save bandwidth, it's recommended to use a custom icon-set in production environments. This pull request provides a custom icon-set to achieve those benefits.