### PR TITLE
Removed paper-styles element

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .bowerrc
 components
 bower_components

--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -3,7 +3,10 @@
 <link rel="import" href="../iron-icon/iron-icon.html">
 <link rel="import" href="../iron-icons/iron-icons.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">
-<link rel="import" href="../paper-styles/paper-styles.html">
+<link rel="import" href="../paper-styles/color.html">
+<link rel="import" href="../paper-styles/default-theme.html">
+<link rel="import" href="../paper-styles/shadow.html">
+<link rel="import" href="../paper-styles/typography.html">
 <link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
 <link rel="import" href="../moment-element/moment-with-locales-import.html">
 
@@ -86,6 +89,8 @@
         left: 0;
         width: 100%;
         opacity: 1;
+        @apply(--layout-horizontal);
+        @apply(--layout-center);
       }
       .month-nav .col {
         position: relative;
@@ -112,9 +117,21 @@
         text-align: center;
         font-weight: bold;
         @apply(--paper-font-body2);
+        @apply(--layout-horizontal);
+        @apply(--layout-center);
+        @apply(--layout-center-justified);
+        @apply(--layout-flex);
       }
       .month-weekdays {
         color: var(--secondary-text-color);
+        @apply(--layout-horizontal);
+        @apply(--layout-justified);
+        @apply(--layout-flex);
+      }
+      .month-days {
+        @apply(--layout-horizontal);
+        @apply(--layout-justified);
+        @apply(--layout-flex);
       }
       .month-col .day {
         cursor: default;
@@ -155,15 +172,21 @@
       .day-item.selected.today .day {
         color: var(--text-primary-color);
       }
+      .flex {
+        @apply(--layout-flex);
+      }
+      .flex-5 {
+        @apply(--layout-flex-5);
+      }
     </style>
     <div id="calendar">
       <div id="months" on-track="_onTrack" class$="{{_contentClass}}">
         <template is="dom-repeat" items="{{_months}}" as="month">
           <div class$="{{_getMonthClass('month', month)}}">
-            <div class="month-row month-name layout horizontal center-center flex">
+            <div class="month-row month-name">
               <span>{{dateFormat(month.date, 'MMMM YYYY', locale)}}</span>
             </div>
-            <div class="month-row month-weekdays week layout horizontal justified flex">
+            <div class="month-row month-weekdays week">
               <template is="dom-repeat" items="{{_weekdays}}">
                 <div class="month-col layout vertical flex">
                   <div class="day">{{item.0}}</div>
@@ -171,7 +194,7 @@
               </template>
             </div>
             <template is="dom-repeat" items="{{month.weeks}}" as="row">
-              <div class="month-row layout horizontal justified flex">
+              <div class="month-row month-days">
                 <template is="dom-repeat" items="{{row}}">
                   <div class="month-col">
                     <div class$="{{_getDayClass('day-item selection', item.date, today, date)}}"
@@ -186,7 +209,7 @@
           </div>
         </template>
       </div>
-      <div id="monthNav" class="month-nav layout horizontal center">
+      <div id="monthNav" class="month-nav">
         <div class="flex col self-stretch">
           <div class="btn" on-tap="_swipePrevMonth">
             <paper-ripple center class="ripple circle"></paper-ripple>

--- a/paper-date-picker.html
+++ b/paper-date-picker.html
@@ -7,7 +7,10 @@
 <link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
 <link rel="import" href="../iron-selector/iron-selector.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
-<link rel="import" href="../paper-styles/paper-styles.html">
+<link rel="import" href="../paper-styles/color.html">
+<link rel="import" href="../paper-styles/default-theme.html">
+<link rel="import" href="../paper-styles/shadow.html">
+<link rel="import" href="../paper-styles/typography.html">
 <link rel="import" href="../moment-element/moment-with-locales-import.html">
 <link rel="import" href="paper-calendar.html">
 <link rel="import" href="paper-date-picker-dialog-style.html">


### PR DESCRIPTION
- Replaced paper-styles import with color, default-theme, shadow and typography elements (per polymer team recommendation: https://elements.polymer-project.org/elements/paper-styles)
- Removed CSS classes from iron-flex-layout-classes and replaced them with mixins (as /deep/ and ::shadow combinators are going away: https://blog.polymer-project.org/announcements/2015/12/01/deprecating-deep/)
- Result: Future-proofed layout, removed deprecated warnings in console