### PR TITLE
Fix detection of transitionend event

### DIFF
--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -286,7 +286,7 @@
         this._updateToday();
         this.currentMonth = this.date.getMonth() + 1;
         this.currentYear = this.date.getFullYear();
-        this._transitionEvent = this.style.WebkitTransition ? 'transitionEnd' : 'webkitTransitionEnd';
+        this._transitionEvent = this._whichTransitionEnd();
       },
       dateFormat: function(date, format, locale) {
         if (!date) {
@@ -669,6 +669,20 @@
         this.today = new Date();
         this.today.setHours(0, 0, 0, 0);
       },
+      _whichTransitionEnd: function() {
+        var transitions = {
+          'WebkitTransition' : 'webkitTransitionEnd',
+          'MozTransition'    : 'transitionend',
+          'OTransition'      : 'oTransitionEnd otransitionend',
+          'transition'       : 'transitionend'
+        };
+
+        for (var t in transitions) {
+          if (this.style[t] !== undefined){
+            return transitions[t];
+          }
+        }
+      }
     });
    })();
   </script>


### PR DESCRIPTION
The transitionend event was incorrectly detected as suggested by @Mipme
in a comment (https://github.com/bendavis78/paper-date-picker/issues/91#issuecomment-205485566).
This patch uses the implementation of https://github.com/EvandroLG/transitionEnd
to detect the eventname to use. It seems to solve issue#91 in both
Firefox and IE.