### PR TITLE
Add missing property declaration for paper-calendar._firstDayOfWeek.

### DIFF
--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -293,7 +293,8 @@
           type: Number
         },
         _contentClass: String,
-        _months: Array
+        _months: Array,
+        _firstDayOfWeek: Number,
       },
       behaviors: [
         Polymer.IronResizableBehavior


### PR DESCRIPTION
Hi,
Just a trivial fix for a missing property which trips up a static code analyzer.