### PR TITLE
Add radix for parseInt().

### DIFF
--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -465,7 +465,7 @@
 
             // If we're dragging outside the bounds, add some resistence
             if (x > 0 || x < (-fullWidth + width)) {
-              if (isNaN(parseInt(this._resistStart))) {
+              if (isNaN(parseInt(this._resistStart, 10))) {
                 this._resistStart = adx;
               }
               var rdx = adx - this._resistStart;
@@ -528,7 +528,7 @@
         return i < 0 ? 0 : i;
       },
       _translateX: function(x, transition, cb) {
-        if (isNaN(parseInt(x))) {
+        if (isNaN(parseInt(x, 10))) {
           throw new Error('Not a number: ' + x);
         }
         this._currentPos = x;


### PR DESCRIPTION
This small fix adds radix 10 to parseInt() calls. This is recommended as standard practice by [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt), and trips up JSCompiler's static analysis which forbids this call due to the possible unintended side effects. Although these calls in this code base do look fine to me.