### PR TITLE
Fix two issue where the CSS mixins were not being applied.

### DIFF
--- a/paper-date-picker.html
+++ b/paper-date-picker.html
@@ -83,7 +83,6 @@ styling:
       }
       #heading {
         width: 168px;
-        @apply(--paper-date-picker-heading);
       }
 
       /** Narrow *********************/
@@ -106,6 +105,7 @@ styling:
         background: var(--default-primary-color);
         @apply(--layout-vertical);
         @apply(--layout-around-justfied);
+        @apply(--paper-date-picker-heading);
       }
       #heading .date,
       #heading .year {

--- a/paper-date-picker.html
+++ b/paper-date-picker.html
@@ -80,6 +80,7 @@ styling:
         width: 512px;
         height: 248px;
         @apply(--layout-horizontal);
+        @apply(--paper-date-picker);
       }
       #heading {
         width: 168px;
@@ -90,6 +91,7 @@ styling:
         width: 328px;
         height: 428px;
         @apply(--layout-vertical);
+        @apply(--paper-date-picker);
       }
       :host([narrow]) #heading {
         width: auto;


### PR DESCRIPTION
Issues addressed:

```css
paper-date-picker {
        --paper-date-picker: {
          height: 200px;
          width: 200px;
        }
}
```

This would leave the size of `#datePicker` to `width: 512px; height: 248px;`, making it overflow the container. Now `--paper-date-picker` is also applied to `#datePicker`.

```css
paper-date-picker {
        --paper-date-picker-heading: {
          display: none;
        }
}
```

The mixin was not being applied, since it was later overwritten by `@apply(--layout-vertical); @apply(--layout-around-justfied);`. It is now applied after the flex mixins.