### PR TITLE
Adds UTC support

### DIFF
--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -267,6 +267,13 @@
           observer: '_localeChanged'
         },
         /**
+         * Whether to use UTC instead of the local timezone.
+         */
+        useUtc: {
+          type: Boolean,
+          value: false
+        },
+        /**
          * The minimum allowed date
          */
         minDate: {
@@ -300,7 +307,7 @@
         Polymer.IronResizableBehavior
       ],
       observers: [
-        '_populate(currentYear, currentMonth, minDate, maxDate, locale)',
+        '_populate(currentYear, currentMonth, minDate, maxDate, locale, useUtc)',
       ],
       listeners: {
         'iron-resize': '_resizeHandler',
@@ -308,17 +315,48 @@
       },
       ready: function() {
         this._updateToday();
-        this.currentMonth = this.date.getMonth() + 1;
-        this.currentYear = this.date.getFullYear();
+        this.currentMonth = this._getMonth(this.date) + 1;
+        this.currentYear = this._getFullYear(this.date);
         this._transitionEvent = this._whichTransitionEnd();
       },
       dateFormat: function(date, format, locale) {
         if (!date) {
           return '';
         }
-        var value = moment(date);
+        var value = this.useUtc ? moment.utc(date) : moment(date);
         value.locale(locale || this.locale);
         return value.format(format);
+      },
+      _makeDate: function(year, month, day) {
+        return this.useUtc ?
+            new Date(Date.UTC(year, month, day)) :
+            new Date(year, month, day);
+      },
+      _getFullYear: function(date) {
+        return this.useUtc ? date.getUTCFullYear() : date.getFullYear();
+      },
+      _getMonth: function(date) {
+        return this.useUtc ? date.getUTCMonth() : date.getMonth();
+      },
+      _getDay: function(date) {
+        return this.useUtc ? date.getUTCDay() : date.getDay();
+      },
+      _getDate: function(date) {
+        return this.useUtc ? date.getUTCDate() : date.getDate();
+      },
+      _setDate: function(date, day) {
+        if (this.useUtc) {
+          date.setUTCDate(day);
+        } else {
+          date.setDate(day);
+        }
+      },
+      _setHours: function(date, hours, minutes, seconds, millis) {
+        if (this.useUtc) {
+          date.setUTCHours(hours, minutes, seconds, millis);
+        } else {
+          date.setDate(hours, minutes, seconds, millis);
+        }
       },
       _localeChanged: function(locale) {
         var localeMoment = moment();
@@ -334,24 +372,24 @@
         var date, month, weeks, day, d, dayInfo, monthData, months = [];
 
         // Make sure currentYear/currentMonth are in min/max range
-        if (minDate && new Date(currentYear, currentMonth, 0) < minDate) {
-          this.currentYear = minDate.getFullYear();
-          this.currentMonth = minDate.getMonth() + 1;
+        if (minDate && this._makeDate(currentYear, currentMonth, 0) < minDate) {
+          this.currentYear = this._getFullYear(minDate);
+          this.currentMonth = this._getMonth(minDate) + 1;
           return;
-        } else if (maxDate && new Date(currentYear, currentMonth - 1, 1) > maxDate) {
-          this.currentYear = maxDate.getFullYear();
-          this.currentMonth = maxDate.getMonth() + 1;
+        } else if (maxDate && this._makeDate(currentYear, currentMonth - 1, 1) > maxDate) {
+          this.currentYear = this._getFullYear(maxDate);
+          this.currentMonth = this._getMonth(maxDate) + 1;
           return;
         }
 
         for (var i=-PRELOAD_MONTHS; i<=PRELOAD_MONTHS; i++) {
           weeks = [[]];
           day = 1;
-          date = new Date(currentYear, currentMonth - 1 + i, 1);
-          month = date.getMonth();
+          date = this._makeDate(currentYear, currentMonth - 1 + i, 1);
+          month = this._getMonth(date);
           monthData = {
-            year: date.getFullYear(),
-            month: date.getMonth() + 1,
+            year: this._getFullYear(date),
+            month: month + 1,
             date: new Date(date)
           };
 
@@ -360,7 +398,7 @@
           }
 
           // add "padding" days
-          var firstDay = date.getDay() - this._firstDayOfWeek;
+          var firstDay = this._getDay(date) - this._firstDayOfWeek;
           if (firstDay < 0) {
             firstDay = 7 + firstDay;
           }
@@ -369,20 +407,20 @@
           }
 
           // add actual days
-          while (date.getMonth() === month) {
+          while (this._getMonth(date) === month) {
             if (weeks[0].length && d % 7 === 0) {
               // start new week
               weeks.push([]);
             }
             dayInfo = {
-              date: new Date(date.getFullYear(), month, day),
+              date: this._makeDate(date.getFullYear(), month, day),
               name: this.dateFormat(date,'YYYY-MM-DD'),
               year: currentYear,
               month: month,
               day: day,
             };
             weeks[weeks.length-1].push(dayInfo);
-            date.setDate(++day);
+            this._setDate(date, ++day);
             d++;
           }
 
@@ -596,9 +634,9 @@
         node.addEventListener(eventName, onceCallback);
       },
       _incrMonth: function(i) {
-        var date = new Date(this.currentYear, this.currentMonth - 1 + i);
-        var year = date.getFullYear();
-        var month = date.getMonth() + 1;
+        var date = this._makeDate(this.currentYear, this.currentMonth - 1 + i, 1);
+        var year = this._getFullYear(date);
+        var month = this._getMonth(date) + 1;
         if (this._monthWithinValidRange(year, month)) {
           this.currentYear = year;
           this.currentMonth = month;
@@ -624,7 +662,7 @@
         // Clone the date object to force Polymer binding to notice a change.
         // But only trigger a notification if there actually is a difference.
         date = new Date(date.getTime());
-        date.setHours(0, 0, 0, 0);
+        this._setHours(date, 0, 0, 0, 0);
         if (oldValue && date.getTime && oldValue.getTime && date.getTime() === oldValue.getTime()) {
           return;
         }
@@ -647,8 +685,8 @@
         return false;
       },
       _monthWithinValidRange: function(year, month) {
-        var monthStart = new Date(year, month-1, 1);
-        var monthEnd = new Date(year, month, 0);
+        var monthStart = this._makeDate(year, month-1, 1);
+        var monthEnd = this._makeDate(year, month, 0);
         return this._withinValidRange(monthStart) || this._withinValidRange(monthEnd);
       },
       _positionSlider: function() {
@@ -687,11 +725,11 @@
         this._updateSelection();
       },
       _getDayName: function(date) {
-        return date.getFullYear() + '-' + (date.getMonth() + 1) + '-' + date.getDate();
+        return this._getFullYear(date) + '-' + (this._getMonth(date) + 1) + '-' + this._getDate(date);
       },
       _updateToday: function() {
         this.today = new Date();
-        this.today.setHours(0, 0, 0, 0);
+        this._setHours(this.today, 0, 0, 0, 0);
       },
       _whichTransitionEnd: function() {
         var transitions = {

--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -355,7 +355,7 @@
         if (this.useUtc) {
           date.setUTCHours(hours, minutes, seconds, millis);
         } else {
-          date.setDate(hours, minutes, seconds, millis);
+          date.setHours(hours, minutes, seconds, millis);
         }
       },
       _localeChanged: function(locale) {

--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -345,18 +345,12 @@
         return this.useUtc ? date.getUTCDate() : date.getDate();
       },
       _setDate: function(date, day) {
-        if (this.useUtc) {
-          date.setUTCDate(day);
-        } else {
-          date.setDate(day);
-        }
+        return this.useUtc ? date.setUTCDate(day) : date.setDate(day);
       },
       _setHours: function(date, hours, minutes, seconds, millis) {
-        if (this.useUtc) {
-          date.setUTCHours(hours, minutes, seconds, millis);
-        } else {
-          date.setHours(hours, minutes, seconds, millis);
-        }
+        return this.useUtc ?
+            date.setUTCHours(hours, minutes, seconds, millis) :
+            date.setHours(hours, minutes, seconds, millis);
       },
       _localeChanged: function(locale) {
         var localeMoment = moment();

--- a/paper-date-picker.html
+++ b/paper-date-picker.html
@@ -163,11 +163,11 @@ styling:
         on-iron-select="_pageSelected">
         <neon-animatable id="chooseDate">
           <paper-calendar id="calendar" locale="{{locale}}" date="{{date}}"
-            min-date="{{minDate}}" max-date="{{maxDate}}">
+            min-date="{{minDate}}" max-date="{{maxDate}}" use-utc="{{useUtc}}">
           </paper-calendar>
         </neon-animatable>
         <neon-animatable id="chooseYear">
-          <paper-year-list id="yearList" date="{{date}}" on-tap="_tapHeadingDate" min="[[_minYear]]" max="[[_maxYear]]"></paper-year-list>
+          <paper-year-list id="yearList" date="{{date}}" on-tap="_tapHeadingDate" min="[[_minYear]]" max="[[_maxYear]]" use-utc="{{useUtc}}"></paper-year-list>
         </neon-animatable>
       </neon-animated-pages>
     </div>
@@ -183,6 +183,13 @@ styling:
         date: {
           type: Date,
           notify: true
+        },
+        /**
+         * Whether to use UTC instead of the local timezone.
+         */
+        useUtc: {
+          type: Boolean,
+          value: false
         },
         /**
          * Maximum screen width at which the picker uses a vertical layout
@@ -250,11 +257,11 @@ styling:
         _selectedPage: String,
         _maxYear: {
           type: Number,
-          computed: '_getFullYear(maxDate)'
+          computed: '_getFullYear(maxDate, useUtc)'
         },
         _minYear: {
           type: Number,
-          computed: '_getFullYear(minDate)'
+          computed: '_getFullYear(minDate, useUtc)'
         }
       },
       behaviors: [
@@ -291,8 +298,11 @@ styling:
       _getHeadingClass: function(pfx, selectedPage) {
         return pfx + ' pg-' + selectedPage;
       },
-      _getFullYear: function(date) {
-        return date ? date.getFullYear() : null;
+      _getFullYear: function(date, useUtc) {
+        if (!date) {
+          return null;
+        }
+        return useUtc ? date.getUTCFullYear() : date.getFullYear();
       },
       _splitHeadingDate: function(date, format, locale) {
         var re = new RegExp(this.headingBreak, 'g');

--- a/paper-year-list.html
+++ b/paper-year-list.html
@@ -177,13 +177,8 @@
         var year =
             this.useUtc ? this.date.getUTCFullYear() : this.date.getFullYear();
         if (selected !== year) {
-          if (this.useUtc) {
-            this.date.setUTCFullYear(selected);
-          } else {
-            this.date.setFullYear(selected);
-          }
           // set the year using a new Date instance for notifying to work
-          this.date = new Date(this.date);
+          this.date = new Date(this.useUtc ? this.date.setUTCFullYear(selected) : this.date.setFullYear(selected));
         }
         this._selectYearInList(selected);
       },

--- a/paper-year-list.html
+++ b/paper-year-list.html
@@ -49,6 +49,13 @@
           observer: '_dateChange'
         },
         /**
+         * Whether to use UTC instead of the local timezone.
+         */
+        useUtc: {
+          type: Boolean,
+          value: false
+        },
+        /**
          * Maximum allowed year.
          */
         max: {
@@ -145,7 +152,7 @@
        * Set 'selected' attribute to the new date's year if it is within range, else set it to null.
        */
       _dateChange: function(date) {
-        var newYear = date.getFullYear();
+        var newYear = this.useUtc ? date.getUTCFullYear() : date.getFullYear();
         this.selected = this._withinRange(newYear) ? newYear : null;
       },
       _maxChange: function(max) {
@@ -167,9 +174,16 @@
           this.$.yearList.clearSelection();
           return;
         }
-        if (selected !== this.date.getFullYear()) {
+        var year =
+            this.useUtc ? this.date.getUTCFullYear() : this.date.getFullYear();
+        if (selected !== year) {
+          if (this.useUtc) {
+            this.date.setUTCFullYear(selected);
+          } else {
+            this.date.setFullYear(selected);
+          }
           // set the year using a new Date instance for notifying to work
-          this.date = new Date(this.date.setFullYear(selected));
+          this.date = new Date(this.date);
         }
         this._selectYearInList(selected);
       },


### PR DESCRIPTION
Adds support for using the elements in UTC mode instead of the local timezone. Fairly straightforward change, required mostly finding all places which use the JS Date API methods that set/get things in local timezone and using the UTC equivalents.

To enable simply add use-utc attribute to paper-date-picker, paper-calendar or paper-year-list.