### PR TITLE
Fixes issue #123

### DIFF
--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -645,6 +645,7 @@
         newDate.setYear(item.year);
         newDate.setMonth(item.month);
         newDate.setDate(item.day);
+        newDate.setHours(0,0,0,0);
         this.date = newDate;
       },
       _isValidDate: function(date) {


### PR DESCRIPTION
fixes the bug when you provide a maxDate value and want to select the… maxDateValue in the dateTimePicker. If you do so without the fix the _withinValidRange function will return false when it gets called with the provided values, since the selected date has a time and maxDate
value has no time... value . Since this is a date picker not a time picker I would
recommend to set the hours to 0 so that the user dont has to provide a time value
