### PR TITLE
Fix maxMonth can not navigate to next year when maxDate in not in cur…

### DIFF
--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -523,7 +523,7 @@
         }.bind(this));
       },
       _swipeNextMonth: function() {
-        if (!this.maxDate || this.currentMonth < this.maxDate.getMonth() + 1) {
+        if (!this.maxDate || this.currentYear < this.maxDate.getFullYear() || this.currentMonth < this.maxDate.getMonth() + 1) {
           this._translateX(-this._containerWidth * 2, 'swipe', function() {
             this.set('_contentClass', '');
             this.transform('translateX(' + this._startPos + 'px)', this.$.months);


### PR DESCRIPTION
Fix maxDate bug stuck on the maxDate month: 
`<paper-date-picker min-date="Apr 01, 2015" max-date="Oct 19, 2017"></paper-date-picker>`

When I click ">", it only navigates to Oct 2016, and stuck there. I could not navigate to next month after Oct 2016. Also when I click "<" to navigate to previous month until Apr 2015, then click ">", the window is stuck on Oct 2015. I also can not navigate to next month after Oct, 2015.
