### PR TITLE
Bug 144 - Fix two bugs for maxDate issue

### DIFF
--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -523,7 +523,7 @@
         }.bind(this));
       },
       _swipeNextMonth: function() {
-        if (!this.maxDate || this.currentMonth < this.maxDate.getMonth() + 1) {
+        if (!this.maxDate || this.currentYear < this.maxDate.getFullYear() || this.currentMonth < this.maxDate.getMonth() + 1) {
           this._translateX(-this._containerWidth * 2, 'swipe', function() {
             this.set('_contentClass', '');
             this.transform('translateX(' + this._startPos + 'px)', this.$.months);

--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -626,7 +626,9 @@
         }
         if (!this._withinValidRange(date)) {
           console.warn('Date outside of valid range: ' + date);
-          this.date = date = oldValue;
+          if(date.getFullYear() == this.maxDate.getFullYear()) {
+            this.date = this.maxDate;
+          }
         }
         this.currentYear = date.getFullYear();
         this.currentMonth = date.getMonth() + 1;


### PR DESCRIPTION
  1.  Issue #142 
`<paper-date-picker min-date="Apr 01, 2015" max-date="Oct 19, 2017"></paper-date-picker>`

When I click ">", it only navigates to Oct 2016, and stuck there. I could not navigate to next month after Oct 2016. Also when I click "<" to navigate to previous month until Apr 2015, then click ">", the window is stuck on Oct 2015. I also can not navigate to next month after Oct, 2015.

2. Issue #143 
`<paper-date-picker min-date="August 10, 2016" max-date="January 13, 2019"></paper-date-picker>`

Default date will be currentDate, then click the year number from calendar and choose "2019" from year list, the new date will be currentMonth/currentDay/2019. The console will continue to output warning messages "Date outside of valid range: " (paper-calendar.html line 628). After thousands of warnings, a new error "Uncaught exception" will output , later another error "Uncaught RangeError: Maximum call stack size exceeded."(Chrome).

In Firefox,  the browser will be frozen and could not response any more.
