### PR TITLE
Fix date change when next month has less days when in current date

### DIFF
--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -642,6 +642,7 @@
         }
         var item = event.model.item;
         var newDate = new Date(this.date.getTime());
+        newDate.setDate(1);
         newDate.setYear(item.year);
         newDate.setMonth(item.month);
         newDate.setDate(item.day);


### PR DESCRIPTION
Current `_tapDay` implementation has a bug which can be easily reproduced in basic demo `index.html`. Just run it, set the date to March 31 and then change it to April 1... you'll see the new date is actually May 1.

This is what happens in JavaScript:

```
> tappedDate = { year: 2017, month: 3, day: 1 } // April 1
> newDate = new Date(2017, 2, 31) // March 31
> newDate.setYear(tappedDate.year)
> newDate.setMonth(tappedDate.month) // it's already May because April doesn't have 31 days
> newDate
Mon May 01 2017 00:00:00 GMT+0200 (CEST)
> newDate.setDate(tappedDate.day) // doesn't change anything
> newDate
Mon May 01 2017 00:00:00 GMT+0200 (CEST)
```

The easiest fix for this as setting date to 1 before doing month changes.

```
> tappedDate = { year: 2017, month: 3, day: 1 } // April 1
> newDate = new Date(2017, 2, 31) // March 31
> newDate.setDate(1)
> newDate.setYear(tappedDate.year)
> newDate.setMonth(tappedDate.month)
> newDate.setDate(tappedDate.day)
> newDate
Sat Apr 01 2017 00:00:00 GMT+0200 (CEST)
```