### PR TITLE
Polymer read only variables should be set internally with this._setPr…

### DIFF
--- a/paper-date-picker.html
+++ b/paper-date-picker.html
@@ -265,7 +265,7 @@ styling:
       },
       ready: function() {
         this.today = this.$.calendar.today;
-        this.isTouch = 'ontouchstart' in window;
+        this._setIsTouch('ontouchstart' in window);
         this._selectPage('chooseDate');
       },
       dateFormat: function() {


### PR DESCRIPTION
When compiling with Babel, the Polymer framework seems to become more strict. In this case, readOnly variables can't be set directly. You have to use the created private setter. 
Thus,` propertyName = value;` would be set by `this._setPropertyName(value);`