### PR TITLE
Update deprecated @apply and var() CSS syntax

### DIFF
--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -27,8 +27,8 @@
         -webkit-tap-highlight-color: rgba(0,0,0,0);
         --ease-in-sine: cubic-bezier(0.47, 0, 0.745, 0.715);
         --ease-out-sine: cubic-bezier(0.39, 0.575, 0.565, 1);
-        @apply(--paper-font-body1);
-        @apply(--paper-calendar);
+        @apply --paper-font-body1;
+        @apply --paper-calendar;
         overflow: hidden;
         -webkit-touch-callout: none;
         -webkit-user-select: none;
@@ -37,17 +37,17 @@
         -ms-user-select: none;
         user-select: none;
 
-        @apply(--paper-calendar);
+        @apply --paper-calendar;
       }
       #calendar {
         position: relative;
         width: 100%;
         height: 100%;
-        @apply(--layout-horizontal);
+        @apply --layout-horizontal;
       }
       #months {
         height: 100%;
-        @apply(--layout-horizontal);
+        @apply --layout-horizontal;
       }
       #months.animating .month-nav {
         opacity: 1;
@@ -66,9 +66,9 @@
       }
       .month {
         height: 100%;
-        @apply(--layout-vertical);
-        @apply(--layout-justified);
-        @apply(--layout-flex);
+        @apply --layout-vertical;
+        @apply --layout-justified;
+        @apply --layout-flex;
       }
 
       .month-row, .month-nav {
@@ -79,8 +79,8 @@
 
       .month-col {
         position: relative;
-        @apply(--layout-vertical);
-        @apply(--layout-flex);
+        @apply --layout-vertical;
+        @apply --layout-flex;
       }
 
       .month-nav {
@@ -89,13 +89,13 @@
         left: 0;
         width: 100%;
         opacity: 1;
-        @apply(--layout-horizontal);
-        @apply(--layout-center);
+        @apply --layout-horizontal;
+        @apply --layout-center;
       }
       .month-nav .col {
         position: relative;
-        @apply(--layout-vertical);
-        @apply(--layout-center-center);
+        @apply --layout-vertical;
+        @apply --layout-center-center;
       }
       .month-nav .btn .icon {
         cursor: pointer;
@@ -116,35 +116,35 @@
         vertical-align: middle;
         text-align: center;
         font-weight: bold;
-        @apply(--paper-font-body2);
-        @apply(--layout-horizontal);
-        @apply(--layout-center);
-        @apply(--layout-center-justified);
-        @apply(--layout-flex);
+        @apply --paper-font-body2;
+        @apply --layout-horizontal;
+        @apply --layout-center;
+        @apply --layout-center-justified;
+        @apply --layout-flex;
       }
       .month-weekdays {
         color: var(--secondary-text-color);
-        @apply(--layout-horizontal);
-        @apply(--layout-justified);
-        @apply(--layout-flex);
+        @apply --layout-horizontal;
+        @apply --layout-justified;
+        @apply --layout-flex;
       }
       .month-days {
-        @apply(--layout-horizontal);
-        @apply(--layout-justified);
-        @apply(--layout-flex);
+        @apply --layout-horizontal;
+        @apply --layout-justified;
+        @apply --layout-flex;
       }
       .month-col .day {
         cursor: default;
         pointer-events: none;
-        @apply(--layout-fit);
-        @apply(--layout-vertical);
-        @apply(--layout-center-center);
+        @apply --layout-fit;
+        @apply --layout-vertical;
+        @apply --layout-center-center;
       }
       .month-col {
         position: relative;
         width: 100%;
         height: 100%;
-        @apply(--layout-center-center);
+        @apply --layout-center-center;
       }
       .day-item {
         border-radius: 100%;
@@ -173,10 +173,10 @@
         color: var(--text-primary-color);
       }
       .flex {
-        @apply(--layout-flex);
+        @apply --layout-flex;
       }
       .flex-5 {
-        @apply(--layout-flex-5);
+        @apply --layout-flex-5;
       }
     </style>
     <div id="calendar">

--- a/paper-date-picker-dialog-style.html
+++ b/paper-date-picker-dialog-style.html
@@ -24,17 +24,17 @@
     <style>
       /* Application of mixins to local .paper-date-picker-dialog elements */
       .paper-date-picker-dialog {
-        @apply(--paper-date-picker-dialog);
+        @apply --paper-date-picker-dialog;
       }
       .paper-date-picker-dialog > paper-date-picker {
         --paper-calendar: {
-          @apply(--paper-date-picker-dialog-calendar);
+          @apply --paper-date-picker-dialog-calendar;
         };
-        @apply(--paper-date-picker-dialog-picker);
+        @apply --paper-date-picker-dialog-picker;
       }
       .paper-date-picker-dialog > paper-date-picker:not([narrow]) {
         --paper-date-picker-heading: {
-          @apply(--paper-date-picker-dialog-heading);
+          @apply --paper-date-picker-dialog-heading;
         };
       }
     </style>

--- a/paper-date-picker.html
+++ b/paper-date-picker.html
@@ -70,28 +70,28 @@ styling:
         user-select: none;
         display: inline-block;
         color: var(--primary-text-color);
-        @apply(--paper-font-body1);
-        @apply(--paper-date-picker);
+        @apply --paper-font-body1;
+        @apply --paper-date-picker;
       }
 
       /** Landscape ******************/
       #datePicker {
         width: 512px;
         height: 248px;
-        @apply(--layout-horizontal);
+        @apply --layout-horizontal;
       }
 
       /** Narrow *********************/
       :host([narrow]) #datePicker {
         width: 328px;
         height: 428px;
-        @apply(--layout-vertical);
+        @apply --layout-vertical;
       }
       :host([narrow]) #heading {
         width: auto;
         height: 96px;
         padding: 16px 24px;
-        @apply(--paper-date-picker-heading--narrow);
+        @apply --paper-date-picker-heading--narrow;
       }
 
       /** Heading ********************/
@@ -102,18 +102,18 @@ styling:
         color: var(--text-primary-color);
         background: var(--default-primary-color);
 
-        @apply(--layout-vertical);
-        @apply(--paper-date-picker-heading);
+        @apply --layout-vertical;
+        @apply --paper-date-picker-heading;
       }
       #heading .date,
       #heading .year {
         cursor: pointer;
       }
       #heading .date {
-        @apply(--paper-font-display1);
+        @apply --paper-font-display1;
         font-weight: bold;
         margin-top: 2px;
-        @apply(--paper-date-picker-heading-date);
+        @apply --paper-date-picker-heading-date;
       }
       #heading div.date {
         letter-spacing: 0.025em;
@@ -122,9 +122,9 @@ styling:
         white-space: nowrap;
       }
       #heading .year {
-        @apply(--paper-font-body2);
+        @apply --paper-font-body2;
         font-size: var(--paper-date-picker-year-size, 16px);
-        @apply(--paper-date-picker-heading-date);
+        @apply --paper-date-picker-heading-date;
       }
       #heading:not(.pg-chooseYear) .year,
       #heading.pg-chooseYear .date {
@@ -136,13 +136,13 @@ styling:
         width: 0 !important;
       }
       #pages {
-        @apply(--layout-flex);
+        @apply --layout-flex;
         width: auto;
         background: var(--default-background-color);
       }
       #calendar {
         --paper-calendar: {
-          @apply(--paper-date-picker-calendar);
+          @apply --paper-date-picker-calendar;
         }
       }
     </style>

--- a/paper-year-list.html
+++ b/paper-year-list.html
@@ -12,7 +12,7 @@
         display: block;
         box-sizing: border-box;
         height: 100%;
-        @apply(--paper-font-common-base);
+        @apply --paper-font-common-base;
         /* for iron-list to fit */
         position: relative;
       }
@@ -28,7 +28,7 @@
         font-size: 24px;
       }
       iron-list {
-        @apply(--layout-fit);
+        @apply --layout-fit;
       }
     </style>
     <iron-list id="yearList" items="[[_years]]">


### PR DESCRIPTION
Polymer 2.0 is production ready, and we advise all projects to begin migration. To aid in that migration, we're writing and applying some automated fixes for the mechanical parts of the upgrade.

This change migrates uses of @apply to remove the deprecated parentheses syntax.

These changes are backwards-compatible with Polymer 1.0 applications.