### PR TITLE
Added checks for min and max date when resetting out of range date

### DIFF
--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -666,9 +666,9 @@
           }
           if (!this._withinValidRange(date)) {
             console.warn('Date outside of valid range: ' + date);
-            if (date.getFullYear() == this.maxDate.getFullYear()) {
+            if (this.maxDate && date.getFullYear() == this.maxDate.getFullYear()) {
               this.date = this.maxDate;
-            } else if (date.getFullYear() == this.minDate.getFullYear()) {
+            } else if (this.minDate && date.getFullYear() == this.minDate.getFullYear()) {
               this.date = this.minDate;
             } else {
               this.date = date = oldValue;


### PR DESCRIPTION
Added checks for min and max date before trying to set the date to one of them in the cause of the date being outside the valid range.

The scenario this supports is when you only have a min date specified and the selected date is less than that date. Currently it crashes when trying to read the full year of the max date which would be null because only a min date is specified.